### PR TITLE
[[GetOwnProperty]] → Undefined | Property Descriptor

### DIFF
--- a/spec/ordinary-and-exotic-object-behaviours.html
+++ b/spec/ordinary-and-exotic-object-behaviours.html
@@ -31,7 +31,7 @@
         </dl>
         <emu-alg>
           1. Assert: IsPropertyKey(_P_) is *true*.
-          1. If Type(_P_) is a Symbol, return *false*.
+          1. If Type(_P_) is a Symbol, return *undefined*.
           1. If _P_ is *"length"*, then
             1. Let _length_ be the length of _T_.[[Sequence]].
             1. Return the PropertyDescriptor { [[Value]]: 𝔽(_length_), [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.


### PR DESCRIPTION
The [[GetOwnProperty]] algorithm for Tuple exotic objects has an early exit step for symbol keys, but the step returned `false`, which isn’t a possible [[GetOwnProperty]] return value. It should return `undefined`.

(TEO’s [[DefineOwnProperty]] never permits definition of such a property, so it’s known not to exist. The explicit early exit is not redundant, though, because the subsequent CanonicalNumericIndexString(P) only has defined behavior for string input.)